### PR TITLE
Recover numba

### DIFF
--- a/benchmarks/eko/benchmark_evol_to_unity.py
+++ b/benchmarks/eko/benchmark_evol_to_unity.py
@@ -49,6 +49,7 @@ class BenchmarkBackwardForward:
         "ev_op_max_order": 1,
         "ev_op_iterations": 1,
         "backward_inversion": "exact",
+        "n_integration_cores": 1,
     }
     g = OperatorGrid.from_dict(
         theory_card,

--- a/benchmarks/lha_paper_bench.py
+++ b/benchmarks/lha_paper_bench.py
@@ -222,14 +222,14 @@ if __name__ == "__main__":
 
     # Benchmark to LHA
     # obj = BenchmarkVFNS()
-    # obj = BenchmarkFFNS()
+    obj = BenchmarkFFNS()
 
-    # obj.benchmark_plain(2)
+    obj.benchmark_plain(0)
     # obj.benchmark_sv(2)
 
     # # VFNS benchmarks with LHA settings
-    programs = ["LHA", "pegasus", "apfel"]
-    for p in programs:
-        obj = BenchmarkRunner(p)
-        # obj.benchmark_plain(2)
-        obj.benchmark_sv(2)
+    # programs = ["LHA", "pegasus", "apfel"]
+    # for p in programs:
+    #     obj = BenchmarkRunner(p)
+    #     # obj.benchmark_plain(2)
+    #     obj.benchmark_sv(2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ bench-run.env.NUMBA_DISABLE_JIT.default = "0"
 lint = "pylint src/**/*.py -E"
 lint-warnings = "pylint src/**/*.py --exit-zero"
 sandbox = "python benchmarks/sandbox.py"
+lha = "python benchmarks/lha_paper_bench.py"
 nav = "ekonav --config benchmarks/banana.yaml"
 navigator = "ekonav --config benchmarks/banana.yaml"
 docs = { "shell" = "cd doc; make html" }

--- a/src/eko/anomalous_dimensions/__init__.py
+++ b/src/eko/anomalous_dimensions/__init__.py
@@ -23,7 +23,7 @@ import numpy as np
 from . import as1, as2, as3, harmonics
 
 
-@nb.njit("Tuple((c16[:,:],c16,c16,c16[:,:],c16[:,:]))(c16[:,:])", cache=True)
+@nb.njit(cache=True)
 def exp_singlet(gamma_S):
     r"""
     Computes the exponential and the eigensystem of the singlet anomalous dimension matrix
@@ -71,7 +71,7 @@ def exp_singlet(gamma_S):
     return exp, lambda_p, lambda_m, e_p, e_m
 
 
-@nb.njit("c16[:](u1,u2,c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_ns(order, mode, n, nf):
     r"""
     Computes the tower of the non-singlet anomalous dimensions
@@ -131,7 +131,7 @@ def gamma_ns(order, mode, n, nf):
     return gamma_ns
 
 
-@nb.njit("c16[:,:,:](u1,c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_singlet(order, n, nf):
     r"""
     Computes the tower of the singlet anomalous dimensions matrices

--- a/src/eko/anomalous_dimensions/aem1.py
+++ b/src/eko/anomalous_dimensions/aem1.py
@@ -5,7 +5,7 @@ from .. import constants
 from . import as1
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def gamma_phq(N):
     """
     Computes the leading-order photon-quark anomalous dimension
@@ -26,7 +26,7 @@ def gamma_phq(N):
     return as1.gamma_gq(N) / constants.CF
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_qph(N, nf):
     """
     Computes the leading-order quark-photon anomalous dimension
@@ -50,7 +50,7 @@ def gamma_qph(N, nf):
     return as1.gamma_qg(N, nf) / constants.TR * constants.NC
 
 
-@nb.njit("c16(u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_phph(nf):
     """
     Computes the leading-order photon-photon anomalous dimension
@@ -71,7 +71,7 @@ def gamma_phph(nf):
     return 2 / 3 * constants.NC * 2 * nf
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def gamma_ns(N, s1):
     """
     Computes the leading-order non-singlet QED anomalous dimension.

--- a/src/eko/anomalous_dimensions/as1.py
+++ b/src/eko/anomalous_dimensions/as1.py
@@ -7,7 +7,7 @@ import numpy as np
 from .. import constants
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def gamma_ns(N, s1):
     """
     Computes the leading-order non-singlet anomalous dimension.
@@ -31,7 +31,7 @@ def gamma_ns(N, s1):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_qg(N, nf):
     """
     Computes the leading-order quark-gluon anomalous dimension
@@ -55,7 +55,7 @@ def gamma_qg(N, nf):
     return result
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def gamma_gq(N):
     """
     Computes the leading-order gluon-quark anomalous dimension
@@ -77,7 +77,7 @@ def gamma_gq(N):
     return result
 
 
-@nb.njit("c16(c16,c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_gg(N, s1, nf):
     """
     Computes the leading-order gluon-gluon anomalous dimension
@@ -103,7 +103,7 @@ def gamma_gg(N, s1, nf):
     return result
 
 
-@nb.njit("c16[:,:](c16,c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_singlet(N, s1, nf):
     r"""
       Computes the leading-order singlet anomalous dimension matrix

--- a/src/eko/anomalous_dimensions/as2.py
+++ b/src/eko/anomalous_dimensions/as2.py
@@ -14,7 +14,7 @@ from .. import constants
 from . import harmonics
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_nsm(n, nf):
     """
     Computes the |NLO| valence-like non-singlet anomalous dimension.
@@ -57,7 +57,7 @@ def gamma_nsm(n, nf):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_nsp(n, nf):
     """
     Computes the |NLO| singlet-like non-singlet anomalous dimension.
@@ -98,7 +98,7 @@ def gamma_nsp(n, nf):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_ps(n, nf):
     """
     Computes the |NLO| pure-singlet quark-quark anomalous dimension.
@@ -125,7 +125,7 @@ def gamma_ps(n, nf):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_qg(n, nf):
     """
     Computes the |NLO| quark-gluon singlet anomalous dimension.
@@ -158,7 +158,7 @@ def gamma_qg(n, nf):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_gq(n, nf):
     """
     Computes the |NLO| gluon-quark singlet anomalous dimension.
@@ -194,7 +194,7 @@ def gamma_gq(n, nf):
     return result
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_gg(n, nf):
     """
     Computes the |NLO| gluon-gluon singlet anomalous dimension.
@@ -232,7 +232,7 @@ def gamma_gg(n, nf):
     return result
 
 
-@nb.njit("c16[:,:](c16,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_singlet(N, nf):
     r"""
       Computes the next-leading-order singlet anomalous dimension matrix

--- a/src/eko/anomalous_dimensions/as3.py
+++ b/src/eko/anomalous_dimensions/as3.py
@@ -16,7 +16,7 @@ zeta2 = harmonics.zeta2
 zeta3 = harmonics.zeta3
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_nsm(n, nf, sx):
     """
     Computes the |NNLO| valence-like non-singlet anomalous dimension.
@@ -93,7 +93,7 @@ def gamma_nsm(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_nsp(n, nf, sx):
     """
     Computes the |NNLO| singlet-like non-singlet anomalous dimension.
@@ -170,7 +170,7 @@ def gamma_nsp(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_nsv(n, nf, sx):
     """
     Computes the |NNLO| valence non-singlet anomalous dimension.
@@ -225,7 +225,7 @@ def gamma_nsv(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_ps(n, nf, sx):
     """
     Computes the |NNLO| pure-singlet quark-quark anomalous dimension.
@@ -297,7 +297,7 @@ def gamma_ps(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_qg(n, nf, sx):
     """
     Computes the |NNLO| quark-gluon singlet anomalous dimension.
@@ -371,7 +371,7 @@ def gamma_qg(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_gq(n, nf, sx):
     """
     Computes the |NNLO| gluon-quark singlet anomalous dimension.
@@ -461,7 +461,7 @@ def gamma_gq(n, nf, sx):
     return result
 
 
-@nb.njit("c16(c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_gg(n, nf, sx):
     """
     Computes the |NNLO| gluon-gluon singlet anomalous dimension.
@@ -549,7 +549,7 @@ def gamma_gg(n, nf, sx):
     return result
 
 
-@nb.njit("c16[:,:](c16,u1,c16[:])", cache=True)
+@nb.njit(cache=True)
 def gamma_singlet(N, nf, sx):
     r"""
       Computes the |NNLO| singlet anomalous dimension matrix

--- a/src/eko/anomalous_dimensions/harmonics.py
+++ b/src/eko/anomalous_dimensions/harmonics.py
@@ -16,7 +16,7 @@ zeta4 = scipy.special.zeta(4)
 zeta5 = scipy.special.zeta(5)
 
 
-@nb.njit("c16(c16,u1)", cache=True)
+@nb.njit(cache=True)
 def cern_polygamma(Z, K):  # pylint: disable=all
     """
     Computes the polygamma functions :math:`\\psi_k(z)`.
@@ -133,7 +133,7 @@ def cern_polygamma(Z, K):  # pylint: disable=all
     # fmt: on
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S1(N):
     r"""
     Computes the harmonic sum :math:`S_1(N)`.
@@ -161,7 +161,7 @@ def harmonic_S1(N):
     return cern_polygamma(N + 1.0, 0) + np.euler_gamma
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S2(N):
     r"""
     Computes the harmonic sum :math:`S_2(N)`.
@@ -189,7 +189,7 @@ def harmonic_S2(N):
     return -cern_polygamma(N + 1.0, 1) + zeta2
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S3(N):
     r"""
     Computes the harmonic sum :math:`S_3(N)`.
@@ -217,7 +217,7 @@ def harmonic_S3(N):
     return 0.5 * cern_polygamma(N + 1.0, 2) + zeta3
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S4(N):
     r"""
     Computes the harmonic sum :math:`S_4(N)`.
@@ -245,7 +245,7 @@ def harmonic_S4(N):
     return zeta4 - 1.0 / 6.0 * cern_polygamma(N + 1.0, 3)
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S5(N):
     r"""
     Computes the harmonic sum :math:`S_5(N)`.
@@ -273,7 +273,7 @@ def harmonic_S5(N):
     return zeta5 + 1.0 / 24.0 * cern_polygamma(N + 1.0, 4)
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g3(N):
     r"""
     Computes the Mellin transform of :math:`\text{Li}_2(x)/(1+x)`.

--- a/src/eko/beta.py
+++ b/src/eko/beta.py
@@ -11,7 +11,7 @@ from . import constants
 from .anomalous_dimensions.harmonics import zeta3
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def beta_0(nf):
     """
     Computes the first coefficient of the QCD beta function.
@@ -32,7 +32,7 @@ def beta_0(nf):
     return beta_0
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def beta_1(nf):
     """
     Computes the second coefficient of the QCD beta function.
@@ -57,7 +57,7 @@ def beta_1(nf):
     return beta_1
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def beta_2(nf):
     """
     Computes the third coefficient of the QCD beta function
@@ -86,7 +86,7 @@ def beta_2(nf):
     return beta_2
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def beta_3(nf):
     """
     Computes the fourth coefficient of the QCD beta function
@@ -113,7 +113,7 @@ def beta_3(nf):
     return beta_3
 
 
-@nb.njit("f8(u1,u1)", cache=True)
+@nb.njit(cache=True)
 def beta(k, nf):
     """
     Compute value of a beta coefficients
@@ -144,7 +144,7 @@ def beta(k, nf):
     return beta_
 
 
-@nb.njit("f8(u1,u1)", cache=True)
+@nb.njit(cache=True)
 def b(k, nf):
     """
     Compute b coefficient.

--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -240,7 +240,6 @@ class Operator:
     """
 
     log_label = "Evolution"
-    n_pools = os.cpu_count()
     # complete list of possible evolution operators labels
     full_labels = br.full_labels
 
@@ -255,6 +254,13 @@ class Operator:
         self.op_members = {}
 
     @property
+    def n_pools(self):
+        n_pools = self.config["n_integration_cores"]
+        if n_pools > 0:
+            return n_pools
+        return os.cpu_count() + n_pools
+
+    @property
     def fact_to_ren(self):
         r"""Returns the factor :math:`(\mu_F/\mu_R)^2`"""
         return self.config["fact_to_ren"]
@@ -264,8 +270,7 @@ class Operator:
         """Returns the scale variation mode"""
         if self.config["ModSV"] is not None:
             return sv.Modes[self.config["ModSV"]]
-        else:
-            return sv.Modes.unvaried
+        return sv.Modes.unvaried
 
     @property
     def int_disp(self):
@@ -466,11 +471,18 @@ class Operator:
         tot_start_time = time.perf_counter()
 
         # run integration in parallel for each grid point
-        with Pool(self.n_pools) as pool:
-            res = pool.map(
+        # or avoid opening a single pool
+        if self.n_pools == 1:
+            res = map(
                 self.run_op_integration,
                 enumerate(np.log(self.int_disp.xgrid_raw)),
             )
+        else:
+            with Pool(self.n_pools) as pool:
+                res = pool.map(
+                    self.run_op_integration,
+                    enumerate(np.log(self.int_disp.xgrid_raw)),
+                )
 
         # collect results
         for k, row in enumerate(res):

--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -26,7 +26,7 @@ from ..member import OpMember
 logger = logging.getLogger(__name__)
 
 
-@nb.njit("c16(c16[:,:],u2,u2)")
+@nb.njit(cache=True)
 def select_singlet_element(ker, mode0, mode1):
     """
     Select element of the singlet matrix
@@ -116,7 +116,7 @@ class QuadKerBase:
         return self.path.prefactor * pj * self.path.jac
 
 
-@nb.njit("f8(f8,u1,u2,u2,string,b1,f8,f8[:,:],f8,f8,f8,f8,u4,u1,u1)", cache=True)
+@nb.njit(cache=True)
 def quad_ker(
     u,
     order,

--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -472,17 +472,12 @@ class Operator:
 
         # run integration in parallel for each grid point
         # or avoid opening a single pool
+        args = (self.run_op_integration, enumerate(np.log(self.int_disp.xgrid_raw)))
         if self.n_pools == 1:
-            res = map(
-                self.run_op_integration,
-                enumerate(np.log(self.int_disp.xgrid_raw)),
-            )
+            res = map(*args)
         else:
             with Pool(self.n_pools) as pool:
-                res = pool.map(
-                    self.run_op_integration,
-                    enumerate(np.log(self.int_disp.xgrid_raw)),
-                )
+                res = pool.map(*args)
 
         # collect results
         for k, row in enumerate(res):

--- a/src/eko/evolution_operator/grid.py
+++ b/src/eko/evolution_operator/grid.py
@@ -126,6 +126,7 @@ class OperatorGrid:
         config["ev_op_iterations"] = operators_card["ev_op_iterations"]
         config["debug_skip_singlet"] = operators_card["debug_skip_singlet"]
         config["debug_skip_non_singlet"] = operators_card["debug_skip_non_singlet"]
+        config["n_integration_cores"] = operators_card["n_integration_cores"]
         config["HQ"] = theory_card["HQ"]
         config["ModSV"] = theory_card["ModSV"]
         q2_grid = np.array(operators_card["Q2grid"], np.float_)

--- a/src/eko/gamma.py
+++ b/src/eko/gamma.py
@@ -9,7 +9,7 @@ import numba as nb
 from .anomalous_dimensions.harmonics import zeta3, zeta4, zeta5
 
 
-@nb.njit("f8()", cache=True)
+@nb.njit(cache=True)
 def gamma_0():
     """
     Computes the first coefficient of the QCD gamma function.
@@ -24,7 +24,7 @@ def gamma_0():
     return 4.0
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_1(nf):
     """
     Computes the second coefficient of the QCD gamma function.
@@ -44,7 +44,7 @@ def gamma_1(nf):
     return 202.0 / 3.0 - 20.0 / 9.0 * nf
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_2(nf):
     """
     Computes the third coefficient of the QCD gamma function.
@@ -64,7 +64,7 @@ def gamma_2(nf):
     return 1249.0 - (2216.0 / 27.0 + 160.0 / 3.0 * zeta3) * nf - 140.0 / 81.0 * nf**2
 
 
-@nb.njit("f8(u1)", cache=True)
+@nb.njit(cache=True)
 def gamma_3(nf):
     """
     Computes the fourth coefficient of the QCD gamma function.
@@ -97,7 +97,7 @@ def gamma_3(nf):
     )
 
 
-@nb.njit("f8(u1,u1)", cache=True)
+@nb.njit(cache=True)
 def gamma(order, nf):
     """
     Compute the value of a gamma coefficient

--- a/src/eko/interpolation.py
+++ b/src/eko/interpolation.py
@@ -76,7 +76,7 @@ class Area:
             yield coef
 
 
-@nb.njit("c16(c16,f8,f8[:,:])", cache=True)
+@nb.njit(cache=True)
 def log_evaluate_Nx(N, logx, area_list):
     r"""
     Evaluates a single logarithmic Lagrange interpolator in N-space multiplied
@@ -133,7 +133,7 @@ def log_evaluate_Nx(N, logx, area_list):
     return res
 
 
-@nb.njit("c16(c16,f8,f8[:,:])", cache=True)
+@nb.njit(cache=True)
 def evaluate_Nx(N, logx, area_list):
     r"""
     Evaluates a single linear Lagrange interpolator in N-space multiplied
@@ -176,7 +176,7 @@ def evaluate_Nx(N, logx, area_list):
     return res
 
 
-@nb.njit("c16(c16,b1,f8,f8[:,:])", cache=True)
+@nb.njit(cache=True)
 def evaluate_grid(N, is_log, logx, area_list):
     """
     Evaluate interpolator in N-space
@@ -208,7 +208,7 @@ def evaluate_grid(N, is_log, logx, area_list):
 _atol_eps = 10 * np.finfo(float).eps
 
 
-@nb.njit("f8(f8,f8[:,:])", cache=True)
+@nb.njit(cache=True)
 def evaluate_x(x, area_list):
     """
     Get a single linear Lagrange interpolator in x-space
@@ -241,7 +241,7 @@ def evaluate_x(x, area_list):
     return res
 
 
-@nb.njit("f8(f8,f8[:,:])", cache=True)
+@nb.njit(cache=True)
 def log_evaluate_x(x, area_list):
     """
     Get a single logarithmic Lagrange interpolator in x-space

--- a/src/eko/kernels/evolution_integrals.py
+++ b/src/eko/kernels/evolution_integrals.py
@@ -15,7 +15,7 @@ import numpy as np
 from .. import beta
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j00(a1, a0, nf):
     r"""
     LO-LO exact evolution integral.
@@ -41,7 +41,7 @@ def j00(a1, a0, nf):
     return np.log(a1 / a0) / beta.beta(0, nf)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j11_exact(a1, a0, nf):
     r"""
     NLO-NLO exact evolution integral.
@@ -70,7 +70,7 @@ def j11_exact(a1, a0, nf):
     return (1.0 / beta_1) * np.log((1.0 + a1 * b1) / (1.0 + a0 * b1))
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j11_expanded(a1, a0, nf):
     r"""
     NLO-NLO expanded evolution integral.
@@ -95,7 +95,7 @@ def j11_expanded(a1, a0, nf):
     return 1.0 / beta.beta(0, nf) * (a1 - a0)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j01_exact(a1, a0, nf):
     r"""
     LO-NLO exact evolution integral.
@@ -122,7 +122,7 @@ def j01_exact(a1, a0, nf):
     return j00(a1, a0, nf) - beta.b(1, nf) * j11_exact(a1, a0, nf)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j01_expanded(a1, a0, nf):
     r"""
     LO-NLO expanded evolution integral.
@@ -147,7 +147,7 @@ def j01_expanded(a1, a0, nf):
     return j00(a1, a0, nf) - beta.b(1, nf) * j11_expanded(a1, a0, nf)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j22_exact(a1, a0, nf):
     r"""
     NNLO-NNLO exact evolution integral.
@@ -190,7 +190,7 @@ def j22_exact(a1, a0, nf):
     )
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j12_exact(a1, a0, nf):
     r"""
     NLO-NNLO exact evolution integral.
@@ -225,7 +225,7 @@ def j12_exact(a1, a0, nf):
     return 2.0 / (beta.beta(0, nf)) * np.real(delta / Delta)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j02_exact(a1, a0, nf):
     r"""
     LO-NNLO exact evolution integral.
@@ -256,7 +256,7 @@ def j02_exact(a1, a0, nf):
     )
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j22_expanded(a1, a0, nf):
     r"""
     NNLO-NNLO expanded evolution integral.
@@ -281,7 +281,7 @@ def j22_expanded(a1, a0, nf):
     return 1 / (2 * beta.beta(0, nf)) * (a1**2 - a0**2)
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j12_expanded(a1, a0, nf):
     r"""
     NLO-NNLO expanded evolution integral.
@@ -308,7 +308,7 @@ def j12_expanded(a1, a0, nf):
     return 1 / beta.beta(0, nf) * (a1 - a0 - b1 / 2 * (a1**2 - a0**2))
 
 
-@nb.njit("f8(f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def j02_expanded(a1, a0, nf):
     r"""
     LO-NNLO expanded evolution integral.

--- a/src/eko/kernels/non_singlet.py
+++ b/src/eko/kernels/non_singlet.py
@@ -11,7 +11,7 @@ from . import evolution_integrals as ei
 from . import utils
 
 
-@nb.njit("c16(c16[:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def lo_exact(gamma_ns, a1, a0, nf):
     """
     |LO| non-singlet exact EKO
@@ -35,7 +35,7 @@ def lo_exact(gamma_ns, a1, a0, nf):
     return np.exp(gamma_ns[0] * ei.j00(a1, a0, nf))
 
 
-@nb.njit("c16(c16[:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nlo_exact(gamma_ns, a1, a0, nf):
     """
     |NLO| non-singlet exact EKO
@@ -61,7 +61,7 @@ def nlo_exact(gamma_ns, a1, a0, nf):
     )
 
 
-@nb.njit("c16(c16[:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nlo_expanded(gamma_ns, a1, a0, nf):
     """
     |NLO| non-singlet expanded EKO
@@ -88,7 +88,7 @@ def nlo_expanded(gamma_ns, a1, a0, nf):
     )
 
 
-@nb.njit("c16(c16[:],f8,f8,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def nlo_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     """
     |NLO| non-singlet truncated EKO
@@ -122,7 +122,7 @@ def nlo_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     return e
 
 
-@nb.njit("c16(c16[:],f8,f8,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def nlo_ordered_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     """
     |NLO| non-singlet ordered-truncated EKO
@@ -161,7 +161,7 @@ def nlo_ordered_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     return e
 
 
-@nb.njit("c16(c16[:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nnlo_exact(gamma_ns, a1, a0, nf):
     """
     |NNLO| non-singlet exact EKO
@@ -189,7 +189,7 @@ def nnlo_exact(gamma_ns, a1, a0, nf):
     )
 
 
-@nb.njit("c16(c16[:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nnlo_expanded(gamma_ns, a1, a0, nf):
     """
     |NNLO| non-singlet expanded EKO
@@ -217,7 +217,7 @@ def nnlo_expanded(gamma_ns, a1, a0, nf):
     )
 
 
-@nb.njit("c16(c16[:],f8,f8,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def nnlo_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     """
     |NNLO| non-singlet truncated EKO
@@ -263,7 +263,7 @@ def nnlo_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     return e
 
 
-@nb.njit("c16(c16[:],f8,f8,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def nnlo_ordered_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     """
     |NNLO| non-singlet ordered truncated EKO
@@ -303,7 +303,7 @@ def nnlo_ordered_truncated(gamma_ns, a1, a0, nf, ev_op_iterations):
     return e
 
 
-@nb.njit("c16(u1,string,c16[:],f8,f8,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def dispatcher(
     order, method, gamma_ns, a1, a0, nf, ev_op_iterations
 ):  # pylint: disable=too-many-return-statements

--- a/src/eko/kernels/singlet.py
+++ b/src/eko/kernels/singlet.py
@@ -12,7 +12,7 @@ from . import evolution_integrals as ei
 from . import utils
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def lo_exact(gamma_singlet, a1, a0, nf):
     """
     Singlet leading order exact EKO
@@ -36,7 +36,7 @@ def lo_exact(gamma_singlet, a1, a0, nf):
     return ad.exp_singlet(gamma_singlet[0] * ei.j00(a1, a0, nf))[0]
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8)", cache=True)
+@nb.njit(cache=True)
 def nlo_decompose(gamma_singlet, j01, j11):
     """
     Singlet next-to-leading order decompose EKO
@@ -64,7 +64,7 @@ def nlo_decompose(gamma_singlet, j01, j11):
     return ad.exp_singlet(gamma_singlet[0] * j01 + gamma_singlet[1] * j11)[0]
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nlo_decompose_exact(gamma_singlet, a1, a0, nf):
     """
     Singlet next-to-leading order decompose-exact EKO
@@ -90,7 +90,7 @@ def nlo_decompose_exact(gamma_singlet, a1, a0, nf):
     )
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nlo_decompose_expanded(gamma_singlet, a1, a0, nf):
     """
     Singlet next-to-leading order decompose-expanded EKO
@@ -116,7 +116,7 @@ def nlo_decompose_expanded(gamma_singlet, a1, a0, nf):
     )
 
 
-@nb.njit("c16[:,:](c16[:,:,:],c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def nnlo_decompose(gamma_singlet, j02, j12, j22):
     """
     Singlet next-to-next-to-leading order decompose EKO
@@ -147,7 +147,7 @@ def nnlo_decompose(gamma_singlet, j02, j12, j22):
     )[0]
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nnlo_decompose_exact(gamma_singlet, a1, a0, nf):
     """
     Singlet next-to-next-to-leading order decompose-exact EKO
@@ -176,7 +176,7 @@ def nnlo_decompose_exact(gamma_singlet, a1, a0, nf):
     )
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1)", cache=True)
+@nb.njit(cache=True)
 def nnlo_decompose_expanded(gamma_singlet, a1, a0, nf):
     """
     Singlet next-to-next-to-leading order decompose-expanded EKO
@@ -205,7 +205,7 @@ def nnlo_decompose_expanded(gamma_singlet, a1, a0, nf):
     )
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1, u1, u4)", cache=True)
+@nb.njit(cache=True)
 def eko_iterate(gamma_singlet, a1, a0, nf, order, ev_op_iterations):
     """
     Singlet NLO or NNLO iterated (exact) EKO
@@ -262,7 +262,7 @@ def eko_iterate(gamma_singlet, a1, a0, nf, order, ev_op_iterations):
     return e
 
 
-@nb.njit("c16[:,:,:](c16[:,:,:],u1,u1,u1,b1)", cache=True)
+@nb.njit(cache=True)
 def r_vec(gamma_singlet, nf, ev_op_max_order, order, is_exact):
     r"""
     Compute singlet R vector for perturbative mode.
@@ -310,7 +310,7 @@ def r_vec(gamma_singlet, nf, ev_op_max_order, order, is_exact):
     return r
 
 
-@nb.njit("c16[:,:,:](c16[:,:,:],u1)", cache=True)
+@nb.njit(cache=True)
 def u_vec(r, ev_op_max_order):
     r"""
     Compute the elements of the singlet U vector.
@@ -351,7 +351,7 @@ def u_vec(r, ev_op_max_order):
     return u
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8)", cache=True)
+@nb.njit(cache=True)
 def sum_u(uvec, a):
     r"""
     Sums up the actual U operator.
@@ -383,7 +383,7 @@ def sum_u(uvec, a):
     return res
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1,u1,u4,u1,b1)", cache=True)
+@nb.njit(cache=True)
 def eko_perturbative(
     gamma_singlet, a1, a0, nf, order, ev_op_iterations, ev_op_max_order, is_exact
 ):
@@ -431,7 +431,7 @@ def eko_perturbative(
     return e
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,f8,u1,u1,u4)", cache=True)
+@nb.njit(cache=True)
 def eko_truncated(gamma_singlet, a1, a0, nf, order, ev_op_iterations):
     """
     Singlet NLO or NNLO truncated EKO
@@ -480,7 +480,7 @@ def eko_truncated(gamma_singlet, a1, a0, nf, order, ev_op_iterations):
     return e
 
 
-@nb.njit("c16[:,:](u1,string,c16[:,:,:],f8,f8,u1,u4,u1)", cache=True)
+@nb.njit(cache=True)
 def dispatcher(  # pylint: disable=too-many-return-statements
     order, method, gamma_singlet, a1, a0, nf, ev_op_iterations, ev_op_max_order
 ):

--- a/src/eko/kernels/utils.py
+++ b/src/eko/kernels/utils.py
@@ -5,7 +5,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("f8[:](f8,f8,u4)", cache=True)
+@nb.njit(cache=True)
 def geomspace(start, end, num):
     """
     Numba port of :func:`numpy.geomspace`.

--- a/src/eko/matching_conditions/as1.py
+++ b/src/eko/matching_conditions/as1.py
@@ -13,7 +13,7 @@ import numpy as np
 from ..constants import CF
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_hh(n, sx, L):
     r"""
     |NLO| heavy-heavy |OME| :math:`A_{HH}^{(1)}` defined as the
@@ -47,7 +47,7 @@ def A_hh(n, sx, L):
     return -CF * (ahh_l * L + ahh)
 
 
-@nb.njit("c16(c16,f8)", cache=True)
+@nb.njit(cache=True)
 def A_gh(n, L):
     r"""
     |NLO| gluon-heavy |OME| :math:`A_{gH}^{(1)}` defined as the
@@ -73,7 +73,7 @@ def A_gh(n, L):
     return 2 * CF * (agh_l0 + agh_l1 * L)
 
 
-@nb.njit("c16(c16,f8)", cache=True)
+@nb.njit(cache=True)
 def A_hg(n, L):
     r"""
     |NLO| heavy-gluon |OME| :math:`A_{Hg}^{S,(1)}` defined as the
@@ -96,7 +96,7 @@ def A_hg(n, L):
     return num * den * L
 
 
-@nb.njit("c16(f8)", cache=True)
+@nb.njit(cache=True)
 def A_gg(L):
     r"""
     |NLO| gluon-gluon |OME| :math:`A_{gg,H}^{S,(1)}` defined as the
@@ -115,7 +115,7 @@ def A_gg(L):
     return -2.0 / 3.0 * L
 
 
-@nb.njit("c16[:,:](c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_singlet(n, sx, L):
     r"""
       Computes the |NLO| singlet |OME|.
@@ -157,7 +157,7 @@ def A_singlet(n, sx, L):
     return A_S
 
 
-@nb.njit("c16[:,:](c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_ns(n, sx, L):
     r"""
       Computes the |NLO| non-singlet |OME| with intrinsic contributions.

--- a/src/eko/matching_conditions/as2.py
+++ b/src/eko/matching_conditions/as2.py
@@ -22,7 +22,7 @@ zeta2 = harmonics.zeta2
 zeta3 = harmonics.zeta3
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_qq_ns(n, sx, L):
     r"""
     |NNLO| light-light non-singlet |OME| :math:`A_{qq,H}^{NS,(2)}` given in
@@ -77,7 +77,7 @@ def A_qq_ns(n, sx, L):
     return constants.CF * constants.TR * (a_qq_l2 * L**2 + a_qq_l1 * L + a_qq_l0)
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_hq_ps(n, sx, L):
     r"""
     |NNLO| heavy-light pure-singlet |OME| :math:`A_{Hq}^{PS,(2)}` given in
@@ -140,7 +140,7 @@ def A_hq_ps(n, sx, L):
     return constants.CF * constants.TR * (a_hq_l2 * L**2 + a_hq_l1 * L + a_hq_l0)
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_hg(n, sx, L):
     r"""
     |NNLO| heavy-gluon |OME| :math:`A_{Hg}^{S,(2)}` given in
@@ -288,7 +288,7 @@ def A_hg(n, sx, L):
     return a_hg_l2 * L**2 + a_hg_l1 * L + a_hg_l0
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_gq(n, sx, L):
     r"""
     |NNLO| gluon-quark |OME| :math:`A_{gq,H}^{S,(2)}` given in
@@ -338,7 +338,7 @@ def A_gq(n, sx, L):
     return constants.CF * constants.TR * (a_gq_l2 * L**2 + a_gq_l1 * L + a_gq_l0)
 
 
-@nb.njit("c16(c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_gg(n, sx, L):
     r"""
     |NNLO| gluon-gluon |OME| :math:`A_{gg,H}^{S,(2)} ` given in
@@ -425,7 +425,7 @@ def A_gg(n, sx, L):
     return a_gg_l2 * L**2 + a_gg_l1 * L + a_gg_l0
 
 
-@nb.njit("c16[:,:](c16,c16[:],f8,b1)", cache=True)
+@nb.njit(cache=True)
 def A_singlet(n, sx, L, is_msbar=False):
     r"""
       Computes the |NNLO| singlet |OME|.
@@ -475,7 +475,7 @@ def A_singlet(n, sx, L, is_msbar=False):
     return A_S
 
 
-@nb.njit("c16[:,:](c16,c16[:],f8)", cache=True)
+@nb.njit(cache=True)
 def A_ns(n, sx, L):
     r"""
       Computes the |NNLO| non-singlet |OME|.

--- a/src/eko/matching_conditions/as3/__init__.py
+++ b/src/eko/matching_conditions/as3/__init__.py
@@ -36,7 +36,7 @@ from .aqqNS import A_qqNS
 from .aqqPS import A_qqPS
 
 
-@nb.njit("c16[:,:](c16,c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_singlet(n, sx_all, nf, L):
     r"""
     Computes the |N3LO| singlet |OME|.
@@ -93,7 +93,7 @@ def A_singlet(n, sx_all, nf, L):
     return A_S
 
 
-@nb.njit("c16[:,:](c16,c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_ns(n, sx_all, nf, L):
     r"""
     Computes the |N3LO| non-singlet |OME|.

--- a/src/eko/matching_conditions/as3/aHg.py
+++ b/src/eko/matching_conditions/as3/aHg.py
@@ -6,7 +6,7 @@ import numpy as np
 from .aHgstfac import A_Hgstfac
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_Hg(n, sx, smx, s3x, s4x, nf, L):  # pylint: disable=too-many-locals
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{Hg}^{S,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/aHgstfac.py
+++ b/src/eko/matching_conditions/as3/aHgstfac.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4)", cache=True)
+@nb.njit(cache=True)
 def A_Hgstfac(n, sx, smx, s3x, s4x, nf):
     r"""
     Computes the approximate incomplete part of :math:`A_{Hg}^{S,(3)}(N)`

--- a/src/eko/matching_conditions/as3/aHq.py
+++ b/src/eko/matching_conditions/as3/aHq.py
@@ -4,7 +4,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_Hq(n, sx, smx, s3x, s4x, nf, L):  # pylint: disable=too-many-locals
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{Hq}^{S,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/agg.py
+++ b/src/eko/matching_conditions/as3/agg.py
@@ -6,7 +6,7 @@ import numpy as np
 from .aggTF2 import A_ggTF2
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_gg(n, sx, smx, s3x, s4x, nf, L):  # pylint: disable=too-many-locals
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{gg}^{S,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/aggTF2.py
+++ b/src/eko/matching_conditions/as3/aggTF2.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],c16[:])", cache=True)
+@nb.njit(cache=True)
 def A_ggTF2(n, sx, s3x):
     r"""
     Computes the approximate incomplete part of :math:`A_{gg}^{S,(3)}(N)`

--- a/src/eko/matching_conditions/as3/agq.py
+++ b/src/eko/matching_conditions/as3/agq.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_gq(n, sx, smx, s3x, s4x, nf, L):  # pylint: disable=too-many-locals
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{gq}^{S,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/aqg.py
+++ b/src/eko/matching_conditions/as3/aqg.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_qg(n, sx, smx, s3x, s4x, nf, L):
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{qg}^{S,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/aqqNS.py
+++ b/src/eko/matching_conditions/as3/aqqNS.py
@@ -5,7 +5,7 @@ import numpy as np
 from . import s_functions as sf
 
 
-@nb.njit("c16(c16,c16[:],c16[:],c16[:],c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_qqNS(n, sx, smx, s3x, s4x, nf, L):  # pylint: disable=too-many-locals
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{qq}^{NS,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/aqqPS.py
+++ b/src/eko/matching_conditions/as3/aqqPS.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_qqPS(n, sx, nf, L):
     r"""
     Computes the |N3LO| singlet |OME| :math:`A_{qq}^{PS,(3)}(N)`.

--- a/src/eko/matching_conditions/as3/f_functions/f11.py
+++ b/src/eko/matching_conditions/as3/f_functions/f11.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F11(n, S1, S2):
     """Implements eq 9.27 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f13.py
+++ b/src/eko/matching_conditions/as3/f_functions/f13.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F13(n, S1, S2):
     """Implements eq 9.29 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f14_f12.py
+++ b/src/eko/matching_conditions/as3/f_functions/f14_f12.py
@@ -9,7 +9,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F14F12(n, S1, S21):
     """Linear combination of :math:`M[( 2 S_{2,2}(x)- Li_2(x)^2/2)/(1+x)](N)`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f16.py
+++ b/src/eko/matching_conditions/as3/f_functions/f16.py
@@ -9,7 +9,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F16(n, S1, Sm1, Sm2, Sm3, Sm21):
     """Implements eq 9.32 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f17.py
+++ b/src/eko/matching_conditions/as3/f_functions/f17.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F17(n, S1, S2, S3):
     """Implements eq 9.35 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f18.py
+++ b/src/eko/matching_conditions/as3/f_functions/f18.py
@@ -9,7 +9,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F18(n, S1, S2, S3):
     """Implements eq 9.36 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f19.py
+++ b/src/eko/matching_conditions/as3/f_functions/f19.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F19(n, S1, S2, S3):
     """Mellin tranfrom of eq 9.3 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/f_functions/f20.py
+++ b/src/eko/matching_conditions/as3/f_functions/f20.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F20(n, Sm1, Sm2, Sm3):
     """Mellin transform of eq 9.5 :cite:`Blumlein:2009ta`"""
     return 2.3148148148148148e-7 * (

--- a/src/eko/matching_conditions/as3/f_functions/f21.py
+++ b/src/eko/matching_conditions/as3/f_functions/f21.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F21(n, Sm1, Sm2, Sm3):
     """Mellin transform of eq 9.4 of :cite:`Blumlein:2009ta`"""
     return 2.3148148148148148e-7 * (

--- a/src/eko/matching_conditions/as3/f_functions/f9.py
+++ b/src/eko/matching_conditions/as3/f_functions/f9.py
@@ -8,7 +8,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def F9(n, S1):
     """Implements eq 9.19 of :cite:`Blumlein:2009ta`"""
     return (

--- a/src/eko/matching_conditions/as3/g_functions.py
+++ b/src/eko/matching_conditions/as3/g_functions.py
@@ -63,7 +63,7 @@ p32 = np.array([-25.0 / 24.0, 2.0, -3.0 / 2.0, 2.0 / 3.0, -1.0 / 8.0])
 p31 = np.array([205.0 / 144.0, -25.0 / 12.0, 23.0 / 24.0, -13.0 / 36.0, 1.0 / 16])
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g4(N):
     r"""
     Computes the Mellin transform of :math:`\text{Li}_2(-x)/(1+x)`.
@@ -90,7 +90,7 @@ def mellin_g4(N):
     return g4
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g5(N):
     r"""
     Computes the Mellin transform of :math:`(\text{Li}_2(x)ln(x))/(1+x)`.
@@ -119,7 +119,7 @@ def mellin_g5(N):
     return g5
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g6(N):
     r"""
     Computes the Mellin transform of :math:`\text{Li}_3(x)/(1+x)`.
@@ -146,7 +146,7 @@ def mellin_g6(N):
     return g6
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g8(N):
     r"""
     Computes the Mellin transform of :math:`S_{1,2}(x)/(1+x)`.
@@ -174,7 +174,7 @@ def mellin_g8(N):
     return g8
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g18(N, S1, S2):
     r"""
     Computes the Mellin transform of :math:`-(\text{Li}_2(x) - \zeta_2)/(1-x)`.
@@ -209,7 +209,7 @@ def mellin_g18(N, S1, S2):
     return g18
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g19(N, S1):
     r"""
     Computes the Mellin transform of :math:`-(\text{Li}_2(-x) + \zeta_2/2)/(1-x)`.
@@ -236,7 +236,7 @@ def mellin_g19(N, S1):
     return g19
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g21(N, S1, S2, S3):
     r"""
     Computes the Mellin transform of :math:`-(S_{1,2}(x) - \zeta_3)/(1-x)`.
@@ -287,7 +287,7 @@ def mellin_g21(N, S1, S2, S3):
     return g21
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def mellin_g22(N):
     r"""
     Computes the Mellin transform of :math:`-(\text{Li}_2(x) ln(x))/(1-x)`.

--- a/src/eko/matching_conditions/as3/s_functions.py
+++ b/src/eko/matching_conditions/as3/s_functions.py
@@ -20,7 +20,7 @@ li4half = 0.517479
 log2 = np.log(2)
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm1(N):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-1}(N)`.
@@ -47,7 +47,7 @@ def harmonic_Sm1(N):
     ) - log2
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm2(N):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2}(N)`.
@@ -74,7 +74,7 @@ def harmonic_Sm2(N):
     ) - zeta2 / 2
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm3(N):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-3}(N)`.
@@ -101,7 +101,7 @@ def harmonic_Sm3(N):
     ) - 3 / 4 * zeta3
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm4(N):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-4}(N)`.
@@ -128,7 +128,7 @@ def harmonic_Sm4(N):
     ) - 7 / 8 * zeta4
 
 
-@nb.njit("c16(c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm5(N):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-5}(N)`.
@@ -155,7 +155,7 @@ def harmonic_Sm5(N):
     ) - 15 / 16 * zeta5
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S21(N, S1, S2):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,1}(N)`
@@ -182,7 +182,7 @@ def harmonic_S21(N, S1, S2):
     return -gf.mellin_g18(N, S1, S2) + 2 * zeta3
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm21(N, Sm1):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,1}(N)`
@@ -213,7 +213,7 @@ def harmonic_Sm21(N, Sm1):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S2m1(N, S2, Sm1, Sm2):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,-1}(N)`
@@ -248,7 +248,7 @@ def harmonic_S2m1(N, S2, Sm1, Sm2):
     )
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm31(N, Sm1, Sm2):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-3,1}(N)`
@@ -284,7 +284,7 @@ def harmonic_Sm31(N, Sm1, Sm2):
     )
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm22(N, Sm31):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,2}(N)`
@@ -313,7 +313,7 @@ def harmonic_Sm22(N, Sm31):
     )
 
 
-@nb.njit("c16(c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm211(N, Sm1):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,1,1}(N)`
@@ -346,7 +346,7 @@ def harmonic_Sm211(N, Sm1):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm2m1(N, S1, S2, Sm2):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,-1}(N)`
@@ -375,7 +375,7 @@ def harmonic_Sm2m1(N, S1, S2, Sm2):
     return -gf.mellin_g19(N, S1) + log2 * (S2 - Sm2) - 5 / 8 * zeta3
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S211(N, S1, S2, S3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,1,1}(N)`
@@ -404,7 +404,7 @@ def harmonic_S211(N, S1, S2, S3):
     return -gf.mellin_g21(N, S1, S2, S3) + 6 / 5 * zeta2**2
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S31(N, S2, S4):
     r"""
     Analytic continuation of harmonic sum :math:`S_{3,1}(N)`
@@ -437,7 +437,7 @@ def harmonic_S31(N, S2, S4):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S41(N, S1, S2, S3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{4,1}(N)`
@@ -467,7 +467,7 @@ def harmonic_S41(N, S1, S2, S3):
     return -f.F9(N, S1) + S1 * zeta4 - S2 * zeta3 + S3 * zeta2
 
 
-@nb.njit("c16(c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S311(N, S1, S2):
     r"""
     Analytic continuation of harmonic sum :math:`S_{3,1,1}(N)`
@@ -495,7 +495,7 @@ def harmonic_S311(N, S1, S2):
     return f.F11(N, S1, S2) + zeta3 * S2 - zeta4 / 4 * S1
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S221(N, S1, S2, S21):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,2,1}(N)`
@@ -532,7 +532,7 @@ def harmonic_S221(N, S1, S2, S21):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm221(N, S1, Sm1, S21, Sm21):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,2,1}(N)`
@@ -570,7 +570,7 @@ def harmonic_Sm221(N, S1, Sm1, S21, Sm21):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16,c16,c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S21m2(N, S1, S2, Sm1, Sm2, Sm3, S21, Sm21, S2m1):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,1,-2}(N)`
@@ -618,7 +618,7 @@ def harmonic_S21m2(N, S1, S2, Sm1, Sm2, Sm3, S21, Sm21, S2m1):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S2111(N, S1, S2, S3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,1,1,1}(N)`
@@ -648,7 +648,7 @@ def harmonic_S2111(N, S1, S2, S3):
     return -f.F17(N, S1, S2, S3) + zeta4 * S1
 
 
-@nb.njit("c16(c16,c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm2111(N, S1, S2, S3, Sm1):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,1,1,1}(N)`
@@ -685,7 +685,7 @@ def harmonic_Sm2111(N, S1, S2, S3, Sm1):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S23(N, S1, S2, S3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,3}(N)`
@@ -719,7 +719,7 @@ def harmonic_S23(N, S1, S2, S3):
     return f.F19(N, S1, S2, S3) + 3 * zeta4 * S1
 
 
-@nb.njit("c16(c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_Sm23(N, Sm1, Sm2, Sm3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{-2,3}(N)`
@@ -759,7 +759,7 @@ def harmonic_Sm23(N, Sm1, Sm2, Sm3):
     )
 
 
-@nb.njit("c16(c16,c16,c16,c16,c16)", cache=True)
+@nb.njit(cache=True)
 def harmonic_S2m3(N, S2, Sm1, Sm2, Sm3):
     r"""
     Analytic continuation of harmonic sum :math:`S_{2,-3}(N)`

--- a/src/eko/matching_conditions/operator_matrix_element.py
+++ b/src/eko/matching_conditions/operator_matrix_element.py
@@ -19,7 +19,7 @@ from .as3 import s_functions
 logger = logging.getLogger(__name__)
 
 
-@nb.njit("c16[:](c16)", cache=True)
+@nb.njit(cache=True)
 def get_smx(n):
     """Get the S-minus cache"""
     return np.array(
@@ -33,7 +33,7 @@ def get_smx(n):
     )
 
 
-@nb.njit("c16[:](c16,c16[:],c16[:])", cache=True)
+@nb.njit(cache=True)
 def get_s3x(n, sx, smx):
     """Get the S-w3 cache"""
     return np.array(
@@ -46,7 +46,7 @@ def get_s3x(n, sx, smx):
     )
 
 
-@nb.njit("c16[:](c16,c16[:],c16[:])", cache=True)
+@nb.njit(cache=True)
 def get_s4x(n, sx, smx):
     """Get the S-w4 cache"""
     Sm31 = s_functions.harmonic_Sm31(n, smx[0], smx[1])
@@ -61,7 +61,7 @@ def get_s4x(n, sx, smx):
     )
 
 
-@nb.njit("c16[:,:,:](u1,c16,c16[:],u4,f8,b1)", cache=True)
+@nb.njit(cache=True)
 def A_singlet(order, n, sx, nf, L, is_msbar):
     r"""
     Computes the tower of the singlet |OME|.
@@ -105,7 +105,7 @@ def A_singlet(order, n, sx, nf, L, is_msbar):
     return A_s
 
 
-@nb.njit("c16[:,:,:](u1,c16,c16[:],u4,f8)", cache=True)
+@nb.njit(cache=True)
 def A_non_singlet(order, n, sx, nf, L):
     r"""
     Computes the tower of the non-singlet |OME|
@@ -145,7 +145,7 @@ def A_non_singlet(order, n, sx, nf, L):
     return A_ns
 
 
-@nb.njit("c16[:,:](c16[:,:,:],u4,f8,string)", cache=True)
+@nb.njit(cache=True)
 def build_ome(A, order, a_s, backward_method):
     r"""
     Construct the matching expansion in :math:`a_s` with the appropriate method.
@@ -197,7 +197,7 @@ def build_ome(A, order, a_s, backward_method):
     return ome
 
 
-@nb.njit("f8(f8,u1,u2,u2,b1,f8,f8[:,:],f8,u1,f8,string,b1)", cache=True)
+@nb.njit(cache=True)
 def quad_ker(
     u, order, mode0, mode1, is_log, logx, areas, a_s, nf, L, backward_method, is_msbar
 ):

--- a/src/eko/mellin.py
+++ b/src/eko/mellin.py
@@ -22,7 +22,7 @@ import numba as nb
 import numpy as np
 
 
-@nb.njit("c16(f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def Talbot_path(t, r, o):
     r"""
     Talbot path.
@@ -56,7 +56,7 @@ def Talbot_path(t, r, o):
     return o + r * complex(re, im)
 
 
-@nb.njit("c16(f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def Talbot_jac(t, r, o):  # pylint: disable=unused-argument
     r"""
     Derivative of Talbot path.
@@ -90,7 +90,7 @@ def Talbot_jac(t, r, o):  # pylint: disable=unused-argument
     return r * np.pi * 2.0 * complex(re, im)
 
 
-@nb.njit("c16(f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def line_path(t, m, c):
     r"""
     Textbook path, i.e. a straight line parallel to the imaginary axis.
@@ -115,7 +115,7 @@ def line_path(t, m, c):
     return complex(c, m * (2 * t - 1))
 
 
-@nb.njit("c16(f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def line_jac(_t, m, _c):
     r"""
     Derivative of Textbook path.
@@ -140,7 +140,7 @@ def line_jac(_t, m, _c):
     return complex(0, m * 2)
 
 
-@nb.njit("c16(f8,f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def edge_path(t, m, c, phi):
     r"""
     Edged path with a given angle.
@@ -169,7 +169,7 @@ def edge_path(t, m, c, phi):
     return c + (t - 0.5) * m * np.exp(complex(0, +phi))
 
 
-@nb.njit("c16(f8,f8,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def edge_jac(t, m, _c, phi):
     r"""
     Derivative of edged path

--- a/src/eko/msbar_masses.py
+++ b/src/eko/msbar_masses.py
@@ -69,7 +69,7 @@ def ker_exact(a0, a1, order, nf):
     return np.exp(val)
 
 
-@nb.njit("f8(f8,f8,u1,u1)", cache=True)
+@nb.njit(cache=True)
 def ker_expanded(a0, a1, order, nf):
     r"""
     Expanded |MSbar| |RGE| kernel

--- a/src/eko/scale_variations/expanded.py
+++ b/src/eko/scale_variations/expanded.py
@@ -10,7 +10,7 @@ import numpy as np
 from .. import beta
 
 
-@nb.njit(["c16(c16[:],f8)", "c16[:,:](c16[:,:,:],f8)"], cache=True)
+@nb.njit(cache=True)
 def gamma_1_variation(gamma, L):
     r"""
     Computes the |NLO| anomalous dimension variation.
@@ -30,7 +30,7 @@ def gamma_1_variation(gamma, L):
     return -L * gamma[0]
 
 
-@nb.njit(["c16(c16[:],f8,f8,c16)", "c16[:,:](c16[:,:,:],f8,f8,c16[:,:])"], cache=True)
+@nb.njit(cache=True)
 def gamma_2_variation(gamma, L, beta0, g0e2):
     r"""
     Computes the |NNLO| anomalous dimension variation.
@@ -54,13 +54,7 @@ def gamma_2_variation(gamma, L, beta0, g0e2):
     return -gamma[1] * L + 1 / 2 * (beta0 * gamma[0] + g0e2) * L**2
 
 
-@nb.njit(
-    [
-        "c16(c16[:],f8,f8,f8,c16,c16,c16)",
-        "c16[:,:](c16[:,:,:],f8,f8,f8,c16[:,:],c16[:,:],c16[:,:])",
-    ],
-    cache=True,
-)
+@nb.njit(cache=True)
 def gamma_3_variation(gamma, L, beta0, beta1, g0e2, g0e3, g1g0):
     r"""
     Computes the |N3LO| anomalous dimension variation.
@@ -94,7 +88,7 @@ def gamma_3_variation(gamma, L, beta0, beta1, g0e2, g0e3, g1g0):
     )
 
 
-@nb.njit("c16(c16[:],f8,u1,u1,f8)", cache=True)
+@nb.njit(cache=True)
 def non_singlet_variation(gamma, a_s, order, nf, L):
     """
     Scale Variation non singlet dispatcher
@@ -131,7 +125,7 @@ def non_singlet_variation(gamma, a_s, order, nf, L):
     return sv_ker
 
 
-@nb.njit("c16[:,:](c16[:,:,:],f8,u1,u1,f8)", cache=True)
+@nb.njit(cache=True)
 def singlet_variation(gamma, a_s, order, nf, L):
     """
     Scale Variation singlet dispatcher

--- a/src/eko/scale_variations/exponentiated.py
+++ b/src/eko/scale_variations/exponentiated.py
@@ -7,7 +7,7 @@ import numba as nb
 from .. import beta
 
 
-@nb.njit(["c16[:,:,:](c16[:,:,:],u1,u1,f8)", "c16[:](c16[:],u1,u1,f8)"], cache=True)
+@nb.njit(cache=True)
 def gamma_variation(gamma, order, nf, L):
     """
     Adjust the anomalous dimensions with the scale variations.

--- a/src/eko/strong_coupling.py
+++ b/src/eko/strong_coupling.py
@@ -36,7 +36,7 @@ def strong_coupling_mod_ev(mod_ev):
     raise ValueError(f"Unknown evolution mode {mod_ev}")
 
 
-@nb.njit("f8(u1,f8,u1,f8,f8)", cache=True)
+@nb.njit(cache=True)
 def as_expanded(order, as_ref, nf, scale_from, scale_to):
     """
     Compute expanded expression.

--- a/src/ekomark/data/db.py
+++ b/src/ekomark/data/db.py
@@ -22,4 +22,4 @@ class Operator(Base):  # pylint: disable=too-few-public-methods
     ev_op_max_order = Column(Integer)
     ev_op_iterations = Column(Integer)
     Q2grid = Column(Text)
-    n_integration_cores = Column(Integer)
+    backward_inversion = Column(Text)

--- a/src/ekomark/data/db.py
+++ b/src/ekomark/data/db.py
@@ -22,3 +22,4 @@ class Operator(Base):  # pylint: disable=too-few-public-methods
     ev_op_max_order = Column(Integer)
     ev_op_iterations = Column(Integer)
     Q2grid = Column(Text)
+    n_integration_cores = Column(Integer)

--- a/src/ekomark/data/operators.py
+++ b/src/ekomark/data/operators.py
@@ -2,6 +2,7 @@
 """
 Operator card configurations.
 """
+import os
 
 from banana.data import cartesian_product, sql
 
@@ -18,6 +19,7 @@ default_card = dict(
     ev_op_max_order=10,
     ev_op_iterations=10,
     backward_inversion="expanded",
+    n_integration_cores=os.cpu_count(),
     Q2grid=[100],
 )
 

--- a/src/ekomark/data/operators.py
+++ b/src/ekomark/data/operators.py
@@ -2,8 +2,6 @@
 """
 Operator card configurations.
 """
-import os
-
 from banana.data import cartesian_product, sql
 
 from eko import interpolation
@@ -19,7 +17,7 @@ default_card = dict(
     ev_op_max_order=10,
     ev_op_iterations=10,
     backward_inversion="expanded",
-    n_integration_cores=os.cpu_count(),
+    n_integration_cores=0,
     Q2grid=[100],
 )
 

--- a/tests/eko/test_ev_op_grid.py
+++ b/tests/eko/test_ev_op_grid.py
@@ -48,6 +48,7 @@ class TestOperatorGrid:
             "ev_op_max_order": 1,
             "ev_op_iterations": 1,
             "backward_inversion": "exact",
+            "n_integration_cores": 1,
         }
         if use_FFNS:
             theory_card["FNS"] = "FFNS"

--- a/tests/eko/test_ev_operator.py
+++ b/tests/eko/test_ev_operator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
 import numpy as np
 import scipy.integrate
@@ -126,7 +127,12 @@ def test_quad_ker(monkeypatch):
 class TestOperator:
     def test_labels(self):
         o = Operator(
-            dict(order=2, debug_skip_non_singlet=False, debug_skip_singlet=False),
+            dict(
+                order=2,
+                debug_skip_non_singlet=False,
+                debug_skip_singlet=False,
+                n_integration_cores=1,
+            ),
             {},
             3,
             1,
@@ -134,13 +140,33 @@ class TestOperator:
         )
         assert sorted(o.labels) == sorted(br.full_labels)
         o = Operator(
-            dict(order=1, debug_skip_non_singlet=True, debug_skip_singlet=True),
+            dict(
+                order=1,
+                debug_skip_non_singlet=True,
+                debug_skip_singlet=True,
+                n_integration_cores=1,
+            ),
             {},
             3,
             1,
             2,
         )
         assert sorted(o.labels) == []
+
+    def test_n_pools(self):
+        excluded_cores = 3
+        o = Operator(
+            dict(
+                order=1,
+                debug_skip_non_singlet=True,
+                debug_skip_singlet=True,
+                n_integration_cores=-excluded_cores,
+            ),
+            {},
+            3,
+            1,
+        )
+        assert o.n_pools == os.cpu_count() - excluded_cores
 
     def test_compute(self, monkeypatch):
         # setup objs
@@ -178,6 +204,7 @@ class TestOperator:
             "ev_op_max_order": 1,
             "ev_op_iterations": 1,
             "backward_inversion": "exact",
+            "n_integration_cores": 1,
         }
         g = OperatorGrid.from_dict(
             theory_card,

--- a/tests/eko/test_ome.py
+++ b/tests/eko/test_ome.py
@@ -369,6 +369,7 @@ class TestOperatorMatrixElement:
         "ev_op_max_order": 1,
         "ev_op_iterations": 1,
         "backward_inversion": "exact",
+        "n_integration_cores": 1,
     }
 
     def test_labels(self):
@@ -384,6 +385,7 @@ class TestOperatorMatrixElement:
                     "ev_op_max_order": 1,
                     "ev_op_iterations": 1,
                     "backward_inversion": "exact",
+                    "n_integration_cores": 1,
                 }
                 g = OperatorGrid.from_dict(
                     self.theory_card,
@@ -516,6 +518,7 @@ class TestOperatorMatrixElement:
             "ev_op_max_order": 1,
             "ev_op_iterations": 1,
             "backward_inversion": "exact",
+            "n_integration_cores": 1,
         }
         t = copy.deepcopy(self.theory_card)
         t["PTO"] = 1

--- a/tests/eko/test_runner.py
+++ b/tests/eko/test_runner.py
@@ -42,6 +42,7 @@ operators_card = {
     "ev_op_max_order": 1,
     "ev_op_iterations": 1,
     "backward_inversion": "exact",
+    "n_integration_cores": 1,
 }
 
 


### PR DESCRIPTION
Here I want to recover the "true" numba behaviour, i.e. compilation just-in-time (and not ahead-of-time)
- I think it is just a matter of removing all signatures (as is done in this commit)
- then `import eko` is immediate and instead running, e.g. the LHA benchmark, has some initialization cost
- tests are still running* and the LHA benchmark is still working -  so I think this works

Please have a look and then we can merge back to #83 

*actually, they are not - because https://github.com/N3PDF/eko/blob/606138fcfc31e0364457ab49e9e9557597e49a42/src/eko/evolution_operator/__init__.py#L243 forces me to do a manual `CTRL+C` in the test shell - and hence I strongly recommend to revert that

PS: I think we introduced the signatures because at some point we had problems with types, i.e. we were not sufficiently casting - hopefully this is gone now ...