### PR TITLE
Fixing bug of ekobox evolve_pdfs with multiple replicas

### DIFF
--- a/benchmarks/ekobox/benchmark_evol_pdf.py
+++ b/benchmarks/ekobox/benchmark_evol_pdf.py
@@ -91,8 +91,14 @@ def benchmark_evolve_more_members(tmp_path, cd, lhapdf_path):
             ev_p.evolve_pdfs(pdfs, theory, op, install=True, name="Debug")
         # ev_pdfs
         _ = lhapdf.mkPDFs("Debug")
+        new_pdf_1 = lhapdf.mkPDF("Debug", 0)
+        new_pdf_2 = lhapdf.mkPDF("Debug", 1)
         info = load.load_info_from_file("Debug")
     assert info["XMin"] == op["interpolation_xgrid"][0]
+    for Q2 in [10, 100]:
+        for x in [1e-7, 0.01, 0.1, 0.2, 0.3]:
+            for pid in [21, 1, 2]:
+                assert new_pdf_1.xfxQ2(pid, x, Q2) != new_pdf_2.xfxQ2(pid, x, Q2)
 
 
 @pytest.mark.isolated

--- a/benchmarks/ekobox/benchmark_evol_pdf.py
+++ b/benchmarks/ekobox/benchmark_evol_pdf.py
@@ -90,11 +90,12 @@ def benchmark_evolve_more_members(tmp_path, cd, lhapdf_path):
         with cd(tmp_path):
             ev_p.evolve_pdfs(pdfs, theory, op, install=True, name="Debug")
         # ev_pdfs
-        _ = lhapdf.mkPDFs("Debug")
+        new_pdfs = lhapdf.mkPDFs("Debug")
         new_pdf_1 = lhapdf.mkPDF("Debug", 0)
         new_pdf_2 = lhapdf.mkPDF("Debug", 1)
         info = load.load_info_from_file("Debug")
     assert info["XMin"] == op["interpolation_xgrid"][0]
+    assert len(pdfs) == len(new_pdfs)
     for Q2 in [10, 100]:
         for x in [1e-7, 0.01, 0.1, 0.2, 0.3]:
             for pid in [21, 1, 2]:

--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -13,6 +13,7 @@ def evolve_pdfs(
     theory_card,
     operators_card,
     path=None,
+    store_path=None,
     targetgrid=None,
     install=False,
     name="Evolved_PDF",
@@ -35,6 +36,9 @@ def evolve_pdfs(
 
         path : str
             path to cached eko output (if "None" it will be recomputed)
+
+        store_path : str
+            path where the eko is stored (if "None" will not be saved)
 
         targetgrid : list(float)
             target x-grid (if different from input x-grid)
@@ -61,6 +65,8 @@ def evolve_pdfs(
             eko_output = eko.output.Output.load_tar(my_path)
     else:
         eko_output = eko.run_dglap(theory_card, operators_card)
+        if store_path is not None:
+            eko_output.dump_tar(store_path)
 
     evolved_PDF_list = []
     for initial_PDF in initial_PDF_list:

--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -79,8 +79,8 @@ def evolve_pdfs(
         info_update=info_update,
     )
     all_member_blocks = []
-    all_blocks = []
     for evolved_PDF in evolved_PDF_list:
+        all_blocks = []
         block = genpdf.generate_block(
             lambda pid, x, Q2, evolved_PDF=evolved_PDF: targetgrid[targetgrid.index(x)]
             * evolved_PDF[Q2]["pdfs"][pid][targetgrid.index(x)],


### PR DESCRIPTION
Solve #130 
The bug was due to the fact that, even if `all_blocks` was supposed to contain all and only the blocks of a certain replica, it was not initialized to zero at the beginning of each loop step on `evolved_PDFs`.